### PR TITLE
一時ファイル生成チェックボックスの修正

### DIFF
--- a/src/gui/Runner.java
+++ b/src/gui/Runner.java
@@ -159,12 +159,14 @@ public class Runner {
     String session = usersessionField.getText().trim();
     String filename = filenameField.getText().trim();
     boolean useffmpeg = ffmpegCheck.isSelected();
-    boolean deleteTs = deleteTemp.isSelected();
+    boolean deleteTs;
     if (!useffmpeg) {
       deleteTemp.setEnabled(false);
       deleteTemp.setSelected(false);
+      deleteTs = false;
     } else {
       deleteTemp.setEnabled(true);
+      deleteTs = deleteTemp.isSelected();
     }
     commandBuilder.commandUpdata(url, session, filename, useffmpeg, deleteTs);
     outputArea.setText(String.join(" ", commandBuilder.getCommandAsString()));


### PR DESCRIPTION
一時ファイルの生成のチェックボックスがONの状態でffmpeg使用チェックボックスをOFFにしてもdeleteコマンドが生成されてしまうバグを修正